### PR TITLE
生成したクロスワードを使いやすいJSON形式にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /target/
 /.bsp/
 /.idea
+.bloop
+/project/project
+/.metals

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,3 @@
+version = "3.6.1"
+runner.dialect = scala213
+indent.defnSite = 2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.watcherExclude": {
+        "**/target": true
+    }
+}

--- a/project/metals.sbt
+++ b/project/metals.sbt
@@ -1,0 +1,6 @@
+// DO NOT EDIT! This file is auto-generated.
+
+// This file enables sbt-bloop to create bloop config files.
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.5.6")
+

--- a/src/main/scala/com/papauschek/api/CrosswordGenerator.scala
+++ b/src/main/scala/com/papauschek/api/CrosswordGenerator.scala
@@ -1,0 +1,49 @@
+package com.papauschek.api
+
+import com.papauschek.puzzle.{Puzzle, PuzzleConfig, PuzzleWords, Point}
+import com.papauschek.ui.{PuzzleGenerator, NewPuzzleMessage}
+import concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.concurrent.Promise
+import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
+import scala.scalajs.js.JSConverters._
+import scalajs.js.Array as JsArray
+import scalajs.js.Promise as JsPromise
+
+/** the API for genarating crossword */
+@JSExportTopLevel("CrosswordGenerator")
+class CrosswordGenerator:
+
+  private var initialPuzzle: Puzzle = Puzzle.empty(PuzzleConfig())
+  private var refinedPuzzle: Puzzle = initialPuzzle
+
+  private var mainInputWords: Seq[String] = Nil
+
+  /** generate the puzzle in the background using web workers and returns as JSON */
+  @JSExport("generateCrossword")
+  def generateCrosswordJs(words: JsArray[String]): JsPromise[String] =
+    generateCrossword(words).toJSPromise
+
+  def generateCrossword(words: JsArray[String]): Future[String] =
+
+    val inputWords: Seq[String] = words.toSeq
+    if (inputWords.nonEmpty) {
+      mainInputWords = PuzzleWords.sortByBest(inputWords)
+      val puzzleConfig = PuzzleConfig(
+        // TODO 動的に変更
+        width = 12,
+        height = 12
+      )
+      
+      val p = PuzzleGenerator.send(NewPuzzleMessage(puzzleConfig, mainInputWords))
+      .map {
+        puzzles => {
+          initialPuzzle = puzzles.maxBy(_.density)
+          refinedPuzzle = initialPuzzle
+          refinedPuzzle.parseToJSON(mainInputWords)
+        }
+      }
+      return p
+    }
+    val error = Promise[String]()
+    error.future


### PR DESCRIPTION
生成されるJSONの形式は下記のような形式としている。
wordListはreact-crosswordで使用されている[データ型](https://github.com/JaredReisinger/react-crossword#cluedata-format)に合わせている。

```
{
  "grid": [
    ["あ", "か", "り"],
    ["ぶ", "-", "-"],
    ["ら", "い", "す"]
  ],
  "wordList": {
    "across": {
      "1": {
        "clue": "あかりのヒント",
        "answer": "あかり",
        "row": 0,
        "col": 0
      },
      "3": {
        "clue": "らいすのヒント",
        "answer": "らいす",
        "row": 2,
        "col": 0
      }
    },
    "down": {
      "2": {
        "clue": "あぶらのヒント",
        "answer": "あぶら",
        "row": 0,
        "col": 0
      }
    }
  },
  "unusedWords": [
    "わわわ"
  ]
}
```